### PR TITLE
fix: add missing base style

### DIFF
--- a/preset.shadcn.ts
+++ b/preset.shadcn.ts
@@ -64,6 +64,15 @@ export function presetShadcn(options: PresetShadcnOptions = {}): Preset<Theme> {
             --ring: 216 34% 17%;
             --radius: 0.5rem
           }
+
+          * {
+            border-color: hsl(var(--border));
+          }
+      
+          body {
+            color: hsl(var(--foreground));
+            background: hsl(var(--background));
+          }
         `,
       },
     ],


### PR DESCRIPTION
Currently, after running `npx shadcn-ui@latest init`, you will get some style like this:

```css
/* other styles */

@layer base {
  * {
    @apply border-border;
  }
  body {
    @apply bg-background text-foreground;
  }
}
```